### PR TITLE
Fix: Update AOB patterns for game version 1.4+

### DIFF
--- a/cpp/src/dllmain.cpp
+++ b/cpp/src/dllmain.cpp
@@ -24,8 +24,8 @@ extern "C" {
 
 constexpr uint16_t TCP_PORT = 28771;
 const char* PCALL_SIG = "48 89 5C 24 ? 57 48 83 EC 40 33 C0 41 8B F8";
-const char* UPDATE_SIG = "48 8B C4 48 89 58 ? 48 89 70 ? 48 89 78 ? 55 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC C0 04 00 00";
-const char* LOADFILE_SIG = "48 89 5C 24 ? 48 89 74 24 ? 55 57 41 56 48 8D AC 24 ? ? ? ? 48 81 EC 40 02 00 00";
+const char* UPDATE_SIG = "48 8B C4 48 89 58 ? 48 89 70 ? 48 89 78 ? 55 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 0F 29 70 ? 0F 29 78 ? 44 0F 29 40 ? 44 0F 29 48 ? 44 0F 29 50 ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 85 ? ? ? ? 48 8B F1";
+const char* LOADFILE_SIG = "48 89 5C 24 ? 48 89 74 24 ? 55 57 41 56 48 8D AC 24 ? ? ? ? 48 81 EC 40 02 00 00 48 8B 05 ? ? ? ? 48 33 C4 48 89 85 ? ? ? ? 48 8B 79 10";
 
 struct Pattern {
     std::vector<uint8_t> bytes;


### PR DESCRIPTION

### Description

Hi @yobson1,

I noticed the recent game update (version 1.4+) has caused some of the AOB patterns to no longer work correctly. This PR provides updated signatures that I've tested and confirmed are working on the current version of the game.

### Changes

*   **`UPDATE_SIG`:** The original signature was incorrect after the game update. It has been replaced with a new, unique pattern.
*   **`LOADFILE_SIG`:** The original signature was no longer unique and matched multiple functions. It has been updated to be specific to the correct function again.

### A Note on Stability

To ensure the new patterns are unique, especially `UPDATE_SIG`, they had to be made significantly longer. While this works perfectly for now, I'm aware that longer, highly specific signatures can sometimes be brittle and may break on future minor updates.

For long-term stability, we could potentially refactor this later to use a more robust method, like scanning for a unique string reference near the function or finding a class vtable and reading the function's address from a stable offset. This is just a thought for the future, as the current patterns are a solid fix.

### Final Words

There's no pressure to merge this as-is. The main goal is just to bring the issue to your attention and provide a working solution. Please feel free to use this, request changes, or close it if you have a different fix in mind.

Thanks for your great work on this project